### PR TITLE
Updates routes and sorted out heading sizes

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -2,7 +2,7 @@ const express = require('express')
 const router = express.Router()
 
 // Route index page
-router.get('/', function (req, res) {
+router.post('/', function (req, res) {
   res.render('index')
 })
 
@@ -16,16 +16,16 @@ router.get('/', function (req, res) {
 // Question: Are you making this application on behalf of somone else?
 // Input type: yes/no
 
-router.get('/application/compensation', function (req, res) {
+router.post('/application/compensation', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var rep = req.query.rep
+  var rep = req.session.data['rep']
 
-  if (rep-1 === 'true') {
+  if (rep === 'yes') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If the variable is any other value (or is missing) render the page requested
-    res.render('application/compensation')
+    res.redirect('/application/compensation')
   }
 })
 
@@ -40,16 +40,16 @@ router.get('/application/compensation', function (req, res) {
 // Question: Have you applied for compensation from any other sources?
 // Input type: yes/no
 
-router.get('/application/declaration', function (req, res) {
+router.post('/application/declaration', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var otherCompensation = req.query.otherCompensation
+  var otherCompensation = req.session.data['otherCompensation']
 
-  if (otherCompensation === 'false') {
+  if (otherCompensation === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/declaration')
+    res.redirect('/application/declaration')
   }
 })
 
@@ -64,16 +64,16 @@ router.get('/application/declaration', function (req, res) {
 // Question: Have you applied for compensation from any other sources?
 // Input type: yes/no
 
-router.get('/application/name', function (req, res) {
+router.post('/application/name', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var declaration = req.query.declaration
+  var declaration = req.session.data['declaration']
 
-  if (declaration === 'false') {
+  if (declaration === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/name')
+    res.redirect('/application/name')
   }
 })
 
@@ -114,16 +114,16 @@ router.get('/application/name', function (req, res) {
 // Question: Are you a British Citizen?
 // Input type: yes/no
 
-router.get('/application/criminal-convictions', function (req, res) {
+router.post('/application/criminal-convictions', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var britishCitizen = req.query.britishCitizen
+  var britishCitizen = req.session.data['britishCitizen']
 
-  if (britishCitizen === 'false') {
+  if (britishCitizen === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/criminal-convictions')
+    res.redirect('/application/criminal-convictions')
   }
 })
 
@@ -138,16 +138,16 @@ router.get('/application/criminal-convictions', function (req, res) {
 // Question: Do you have any unspent criminal convictions?
 // Input type: yes/no
 
-router.get('/application/incident-reported', function (req, res) {
+router.post('/application/incident-reported', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var criminalConvictions = req.query.criminalConvictions
+  var criminalConvictions = req.session.data['criminalConvictions']
 
-  if (criminalConvictions === 'true') {
+  if (criminalConvictions === 'yes') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/incident-reported')
+    res.redirect('/application/incident-reported')
   }
 })
 
@@ -164,11 +164,11 @@ router.get('/application/incident-reported', function (req, res) {
 // Question: Was the incident reported to the police?
 // Input type: yes/no
 
-router.get('/application/incident-date', function (req, res) {
+router.post('/application/incident-date', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var incidentReported = req.query.incidentReported
+  var incidentReported = req.session.data['incidentReported']
 
-  if (incidentReported === 'false') {
+  if (incidentReported === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
@@ -203,11 +203,11 @@ router.get('/application/incident-date', function (req, res) {
 // Question: Did the incident happen in the England, Scotland or Wales?
 // Input type: yes/no
 
-router.get('/application/crime-reference', function (req, res) {
+router.post('/application/crime-reference', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var incidentLocation = req.query.incidentLocation
+  var incidentLocation = req.session.data['incidentLocation']
 
-  if (incidentLocation === 'false') {
+  if (incidentLocation === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
@@ -272,16 +272,16 @@ router.get('/application/crime-reference', function (req, res) {
 // Question: Did you receive medical treatment for your injuries?
 // Input type: yes/no
 
-router.get('/application/treatment-date', function (req, res) {
+router.post('/application/treatment-date', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var medicalTreatment = req.query.medicalTreatment
+  var medicalTreatment = req.session.data['medicalTreatment']
 
-  if (medicalTreatment === 'false') {
+  if (medicalTreatment === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/treatment-date')
+    res.redirect('/application/treatment-date')
   }
 })
 
@@ -311,16 +311,16 @@ router.get('/application/treatment-date', function (req, res) {
 // Question: As a result of your injuries were you unable to work?
 // Input type: yes/no
 
-router.get('/application/return-to-work', function (req, res) {
+router.post('/application/return-to-work', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var unableToWork = req.query.unableToWork
+  var unableToWork = req.session.data['unableToWork']
 
-  if (unableToWork === 'false') {
+  if (unableToWork === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/return-to-work')
+    res.redirect('/application/return-to-work')
   }
 })
 
@@ -336,16 +336,16 @@ router.get('/application/return-to-work', function (req, res) {
 // Question: Have you been able to return to paid work?
 // Input type: yes/no
 
-router.get('/application/date-returned-to-work', function (req, res) {
+router.post('/application/date-returned-to-work', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var returnToWork = req.query.returnToWork
+  var returnToWork = req.session.data['returnToWork']
 
-  if (returnToWork === 'false') {
+  if (returnToWork === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/date-returned-to-work')
+    res.redirect('/application/date-returned-to-work')
   }
 })
 
@@ -374,16 +374,16 @@ router.get('/application/date-returned-to-work', function (req, res) {
 // Question: As a result of your injuries have you had to buy equiptment or services that you did not need before you were <mugged>
 // Input type: yes/no
 
-router.get('/application/what-equiptment-or-services', function (req, res) {
+router.post('/application/what-equiptment-or-services', function (req, res) {
   // Get the answer from the query string (eg. ?over18=false)
-  var equiptmentOrServices = req.query.equiptmentOrServices
+  var equiptmentOrServices = req.session.data['equiptmentOrServices']
 
-  if (equiptmentOrServices === 'false') {
+  if (equiptmentOrServices === 'no') {
     // Redirect to the relevant page
     res.redirect('/application/prototype')
   } else {
     // If over18 is any other value (or is missing) render the page requested
-    res.render('application/what-equiptment-or-services')
+    res.redirect('/application/what-equiptment-or-services')
   }
 })
 

--- a/app/views/application/british-citizen.html
+++ b/app/views/application/british-citizen.html
@@ -25,8 +25,8 @@
 
           {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "britishCitizen",
+            "name": "britishCitizen",
             "fieldset": {
               "legend": {
                 "text": 'Are you a British citizen?',

--- a/app/views/application/compensation.html
+++ b/app/views/application/compensation.html
@@ -21,7 +21,7 @@
             "legend": {
             "text": 'Have you applied for compensation from any other sources?',
             "isPageHeading": true,
-            "classes": 'govuk-fieldset__legend--l'
+            "classes": 'govuk-fieldset__legend--xl'
             }
             },
             "items": [

--- a/app/views/application/crime-reference.html
+++ b/app/views/application/crime-reference.html
@@ -16,7 +16,7 @@
             "label": {
             "text": "What is the crime reference number for the incident?",
             "isPageHeading": true,
-            "classes": 'govuk-heading-l'
+            "classes": 'govuk-label--xl'
             },
             "classes": 'govuk-input--width-20',
             "id": "national-insurance-number",
@@ -24,7 +24,7 @@
             }) }}
 
             {% from "button/macro.njk" import govukButton %}
-            
+
             {{ govukButton({
             "text": "Continue"
             }) }}

--- a/app/views/application/criminal-convictions.html
+++ b/app/views/application/criminal-convictions.html
@@ -25,8 +25,8 @@
 
           {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "criminalConvictions",
+            "name": "criminalConvictions",
             "fieldset": {
               "legend": {
                 "text": 'Do you have any unspent criminal convictions?',

--- a/app/views/application/declaration.html
+++ b/app/views/application/declaration.html
@@ -8,12 +8,12 @@
     <main role="main" class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">
+          <h1 class="govuk-heading-xl">
           Declaration
           </h1>
           <p class="govuk-body">All of the information you give on the following screens should be true to the best of your knowledge.</p>
           <form class="form" action="name" method="post">
-            
+
             {% from 'radios/macro.njk' import govukRadios %}
             {{ govukRadios({
             "classes": "govuk-radios--inline",
@@ -42,7 +42,7 @@
             {{ govukButton({
             "text": "Continue"
             }) }}
-            
+
           </form>
         </div>
       </div>

--- a/app/views/application/describe-incident.html
+++ b/app/views/application/describe-incident.html
@@ -11,7 +11,18 @@
           <form class="form" action="injury-selection" method="post">
 
             {% from "input/macro.njk" import govukInput %}
-            {{ govukInput({ "label": { "text": "Describe the incident in your own words" }, "hint": { "html": "We will use this when we talk to you about the incident." }, "id": "national-insurance-number", "name": "national-insurance-number"
+            {{ govukInput({
+            "label": {
+            "text": "Describe the incident in your own words",
+            "isPageHeading": true,
+            "classes": 'govuk-label--xl'
+            },
+            "hint": {
+              "html": "We will use this when we talk to you about the incident."
+            },
+            "classes": 'govuk-input--width-20',
+            "id": "national-insurance-number",
+            "name": "national-insurance-number"
             }) }}
 
             {% from "button/macro.njk" import govukButton %}

--- a/app/views/application/equiptment-or-services.html
+++ b/app/views/application/equiptment-or-services.html
@@ -21,8 +21,8 @@
 
           {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "equiptmentOrServices",
+            "name": "equiptmentOrServices",
             "fieldset": {
               "legend": {
                 "text": 'As a result of your injuries have you had to buy equiptment or services that you did not need before you were mugged?',

--- a/app/views/application/incident-location.html
+++ b/app/views/application/incident-location.html
@@ -25,8 +25,8 @@
 
           {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "incidentLocation",
+            "name": "incidentLocation",
             "fieldset": {
               "legend": {
                 "text": 'Did the incident happen in the England, Scotland or Wales?',

--- a/app/views/application/incident-reported.html
+++ b/app/views/application/incident-reported.html
@@ -25,8 +25,8 @@
 
           {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "incidentReported",
+            "name": "incidentReported",
             "fieldset": {
               "legend": {
                 "text": 'Was the incident reported to the police?',

--- a/app/views/application/injury-selection.html
+++ b/app/views/application/injury-selection.html
@@ -6,8 +6,21 @@
       <div class="govuk-grid-column-two-thirds">
         <form class="form" action="medical-treatment" method="post">
 
-          {% from "input/macro.njk" import govukInput %} {{ govukInput({ "label": { "text": "What injuries did you suffer as a result of the incident?" }, "id": "national-insurance-number", "name": "national-insurance-number" }) }} {% from "button/macro.njk" import
-          govukButton %} {{ govukButton({ "text": "Continue" }) }}
+          {% from "input/macro.njk" import govukInput %}
+
+          {{ govukInput({
+          "label": {
+          "text": "What injuries did you suffer as a result of the incident?",
+          "isPageHeading": true,
+          "classes": 'govuk-label--xl'
+          },
+          "classes": 'govuk-input--width-20',
+          "id": "national-insurance-number",
+          "name": "national-insurance-number"
+          }) }}
+
+          {% from "button/macro.njk" import govukButton %}
+          {{ govukButton({ "text": "Continue" }) }}
 
         </form>
       </div>

--- a/app/views/application/medical-treatment.html
+++ b/app/views/application/medical-treatment.html
@@ -15,13 +15,13 @@
             {% from 'radios/macro.njk' import govukRadios %}
             {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "medicalTreatment",
+            "name": "medicalTreatment",
             "fieldset": {
             "legend": {
             "text": 'Did you receive medical treatment for your injuries?',
             "isPageHeading": true,
-            "classes": 'govuk-fieldset__legend--l'
+            "classes": 'govuk-fieldset__legend--xl'
             }
             },
             "items": [

--- a/app/views/application/name.html
+++ b/app/views/application/name.html
@@ -9,7 +9,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <form class="form" action="date-of-birth" method="post">
-            
+
             <!-- <h1 class="govuk-heading-l">
             What is your full name?
             </h1> -->
@@ -20,7 +20,7 @@
             "label": {
             "text": "What is your full name?",
             "isPageHeading": true,
-            "classes": 'govuk-heading-l'
+            "classes": 'govuk-label--xl'
             },
             "classes": 'govuk-input--width-20',
             "id": "national-insurance-number",
@@ -28,7 +28,7 @@
             }) }}
 
             {% from "button/macro.njk" import govukButton %}
-            
+
             {{ govukButton({
             "text": "Continue"
             }) }}

--- a/app/views/application/prototype.html
+++ b/app/views/application/prototype.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block page_title %}
+  Question page
+{% endblock %}
+{% block content %}
+  <div class="govuk-width-container">
+    <a class="govuk-back-link" href="/start-page">Back</a>
+    <main role="main" class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-xl">
+          This is a prototype
+          </h1>
+          <p class="govuk-body">you have arrived at a page we have not thought about yet.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/application/return-to-work.html
+++ b/app/views/application/return-to-work.html
@@ -15,13 +15,13 @@
             {% from 'radios/macro.njk' import govukRadios %}
             {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "returnToWork",
+            "name": "returnToWork",
             "fieldset": {
             "legend": {
             "text": 'Have you been able to return to paid work?',
             "isPageHeading": true,
-            "classes": 'govuk-fieldset__legend--l'
+            "classes": 'govuk-fieldset__legend--xl'
             }
             },
             "items": [

--- a/app/views/application/unable-to-work.html
+++ b/app/views/application/unable-to-work.html
@@ -15,13 +15,13 @@
             {% from 'radios/macro.njk' import govukRadios %}
             {{ govukRadios({
             "classes": "govuk-radios--inline",
-            "idPrefix": "otherCompensation",
-            "name": "otherCompensation",
+            "idPrefix": "unableToWork",
+            "name": "unableToWork",
             "fieldset": {
             "legend": {
             "text": 'As a result of your injuries were you unable to work?',
             "isPageHeading": true,
-            "classes": 'govuk-fieldset__legend--l'
+            "classes": 'govuk-fieldset__legend--xl'
             }
             },
             "items": [

--- a/app/views/application/what-equiptment-or-services.html
+++ b/app/views/application/what-equiptment-or-services.html
@@ -20,7 +20,7 @@
             "label": {
             "text": "What have you had to buy?",
             "isPageHeading": true,
-            "classes": 'govuk-heading-l'
+            "classes": 'govuk-label--xl'
             },
             "classes": 'govuk-input--width-20',
             "id": "national-insurance-number",

--- a/app/views/application/who-is-making-the-application.html
+++ b/app/views/application/who-is-making-the-application.html
@@ -19,7 +19,7 @@
             "legend": {
             "text": 'Are you making this application on behalf of someone else?',
             "isPageHeading": true,
-            "classes": 'govuk-fieldset__legend--l'
+            "classes": 'govuk-fieldset__legend--xl'
             }
             },
             "items": [


### PR DESCRIPTION
**This PR contains:**
- updates to all the routes for the prototype so they don't use `get` and put information in the URL instead the prototype is now getting all of the information from the session date using `rec.session.data`
- for the branching routes, they are all now using the `res.redirect` method rather than `res.render`
- all pages have been updated to use the gov.uk macros from the BETA of the design system.
- a prototype page to use to dead-end users if they stray in to areas that have not been designed
