### PR TITLE
Removed the current sprint version from the current version heading

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -35,7 +35,7 @@
           <!-- <span class="govuk-caption-m">Sprint 14 & 15</span> -->
         </h2>
 
-        <h3 class="govuk-heading-l"><a href="/start-page">Current version</a><span class="govuk-caption-m">MVP Sprint 5</span></h3>
+        <h3 class="govuk-heading-l"><a href="/start-page">Current version</a></h3>
 
 
         <h3 class="govuk-heading-l"><a href="https://cica-app-r13.herokuapp.com/start-page">Release 13</a><span class="govuk-caption-m">MVP Sprint 7</span></h3>


### PR DESCRIPTION
We keep forgetting to update the sprint so I've removed this to solve the problem.

![image](https://user-images.githubusercontent.com/868772/48129117-7b78b680-e280-11e8-915d-dfdcbf4c62fa.png)
