### PR TITLE
MVP-515 Move hint text from 1st to 2nd page of offender name series

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -26,7 +26,7 @@
 	    declarationBody: 'By continuing you confirm that the information you will give is true as far as you know.',
 	    declarationHeading: 'Declaration',
 	    doYouKnowOffenderQuestion: "Do you know the name of the offender?",
-	    doYouKnowOffenderHint: "We will not contact them.",
+	    offenderNameHint: "We will not contact the offender.",
 	    emailAddressError: "Enter your email address, for example john.smith@email.com",
 	    emailAddressErrorSubHeader: "Enter your email address?",
 	    emailAddressHint: "We'll use this to contact you about your application for example, to request more information and tell you about our decision",

--- a/app/views/application/do-you-know-offender/index.html
+++ b/app/views/application/do-you-know-offender/index.html
@@ -36,9 +36,6 @@
                   classes: "govuk-fieldset__legend--xl"
                 }
               },
-              hint: {
-                text: doYouKnowOffenderHint
-              },
               items: [
                 {
                   value: "Yes",

--- a/app/views/application/offender-name/index.html
+++ b/app/views/application/offender-name/index.html
@@ -28,7 +28,9 @@
               {{ offenderNameQuestion }}
             </label>
           </h1>
-
+          <span id="waste-hint" class="govuk-hint">
+               {{ offenderNameHint }}
+             </span>
         </div>
 
         {% from "input/macro.njk" import govukInput %}


### PR DESCRIPTION
Moved and refined the offender name hint text from the first question of the series to the next one.
screenshots below
<img width="458" alt="mvp-515 do you know offender" src="https://user-images.githubusercontent.com/34911484/48852896-41420580-eda6-11e8-8c68-2e6e8f1082f3.PNG">
<img width="398" alt="mvp-515 enter offender name" src="https://user-images.githubusercontent.com/34911484/48852901-430bc900-eda6-11e8-8cd9-cd69c749de45.PNG">
