### PR TITLE
2 Error states and content changes for address postcode lookup

### DIFF
--- a/app/views/application/address/error-blank-postcode.html
+++ b/app/views/application/address/error-blank-postcode.html
@@ -22,7 +22,17 @@
   <div class="govuk-grid-column-two-thirds">
 
     <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
 
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: "Enter your postcode",
+                  href: "#haveOtherName"
+                }
+              ]
+            }) }}
       {% from "input/macro.njk" import govukInput %}
       {% from "fieldset/macro.njk" import govukFieldset %}
       {% from "details/macro.njk" import govukDetails %}
@@ -43,14 +53,15 @@
           classes: "govuk-input--width-10",
           id: "postcode",
           name: "postcode",
-          value: data['postcode']
+          value: data['postcode'],
+          errorMessage: {
+            text: "Enter your postcode"
+          }
         }) }}
 
-      {{ govukButton({
-          "text": "Find address"
-          }) }}
-
-
+        {{ govukButton({
+            "text": "Find address"
+            }) }}
 
           <div class="govuk-body">
             <p>

--- a/app/views/application/address/error-invalid-postcode.html
+++ b/app/views/application/address/error-invalid-postcode.html
@@ -22,7 +22,17 @@
   <div class="govuk-grid-column-two-thirds">
 
     <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
 
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: "Enter a real postcode",
+                  href: "#haveOtherName"
+                }
+              ]
+            }) }}
       {% from "input/macro.njk" import govukInput %}
       {% from "fieldset/macro.njk" import govukFieldset %}
       {% from "details/macro.njk" import govukDetails %}
@@ -43,23 +53,24 @@
           classes: "govuk-input--width-10",
           id: "postcode",
           name: "postcode",
-          value: data['postcode']
+          value: data['postcode'],
+          errorMessage: {
+            text: "Enter a real postcode"
+          }
         }) }}
 
-      {{ govukButton({
-          "text": "Find address"
-          }) }}
+        {{ govukButton({
+            "text": "Find address"
+            }) }}
 
-
-
-          <div class="govuk-body">
-            <p>
-              <a href="address-manually">I do not know my postcode</a>
-            </p>
-            <p>
-              <a href="address-non-UK">I live outside the UK</a>
-            </p>
-          </div>
+            <div class="govuk-body">
+              <p>
+                <a href="address-manually">I do not know my postcode</a>
+              </p>
+              <p>
+                <a href="address-non-UK">I live outside the UK</a>
+              </p>
+            </div>
 
     </form>
   </div>

--- a/app/views/application/address/routes.js
+++ b/app/views/application/address/routes.js
@@ -19,5 +19,13 @@ module.exports = function (router, content) {
     }
     res.redirect('/application/phone-number')
   })
+
+  router.get('/application/address/error-invalid-postcode', function (req, res) {
+    res.render('application/address/error-invalid-postcode', content)
+  })
+
+  router.get('/application/address/error-blank-postcode', function (req, res) {
+    res.render('application/address/error-blank-postcode', content)
+  })
   // END__######################################################################################################
 }


### PR DESCRIPTION
2 error screens created for

- no postcode entered
- invalid/incomplete postcode entered

Content also refined - removed reveal so that manual address and non-UK links persist on screen.  Wording of links and "find" button also refined in line with other gov.uk examples.

![mvp-392 address - postcode](https://user-images.githubusercontent.com/34911484/49292978-a54f8280-f4a6-11e8-8486-ea0d9bdc8034.png)
![mvp-392 address error - blank postcode](https://user-images.githubusercontent.com/34911484/49292979-a54f8280-f4a6-11e8-9c20-633636bc54fd.png)
![mvp-392 address error - invalid postcode](https://user-images.githubusercontent.com/34911484/49292980-a54f8280-f4a6-11e8-90b4-e3611ce01bb0.png)
