### PR TITLE
MVP-526 Error state for phone number

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -88,6 +88,7 @@
 	    periodOfAbuseStartQuestion: 'When did it start?',
 	    phoneNumberHint: "We'll use this to contact you about your application for example, to request more information",
 	    phoneNumberQuestion: "Enter your telephone number",
+			phoneNumberError: 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192',
 	    policeForceHint: "Enter the police force name, for example, Humberside police.",
 	    policeForceQuestion: 'Was the crime reported to Police Scotland Greater Glasgow?',
       policeForceManualQuestion: 'What force was the crime reported to?',

--- a/app/views/application/phone-number/error.html
+++ b/app/views/application/phone-number/error.html
@@ -1,0 +1,69 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+{{ phoneNumberQuestion }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" method="post">
+
+      <!-- <h1 class="govuk-heading-l">
+            What is your full name?
+            </h1> -->
+
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: phoneNumberQuestion,
+                  href: "#phoneNumber"
+                }
+              ]
+            }) }}
+
+      {{ govukInput({
+            "label": {
+            "text": phoneNumberQuestion,
+            "isPageHeading": true,
+            "classes": 'govuk-label--xl'
+            },
+            hint: {
+              text: phoneNumberHint
+            },
+          errorMessage: {
+          text: phoneNumberError
+          },
+            "classes": 'govuk-input--width-20',
+            "id": "phoneNumber",
+            "name": "phoneNumber",
+            "value": data['phoneNumber']
+            }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+
+      {{ govukButton({
+            "text": "Continue"
+            }) }}
+
+    </form>
+  </div>
+</div>
+</main>
+</div>
+{% endblock %}

--- a/app/views/application/phone-number/routes.js
+++ b/app/views/application/phone-number/routes.js
@@ -13,5 +13,9 @@ module.exports = function (router, content) {
   router.get('/application/phone-number/', function (req, res) {
     res.render('application/phone-number/index', content)
   })
+
+  router.get('/application/phone-number/error', function (req, res) {
+    res.render('application/phone-number/error', content)
+  })
   // END__######################################################################################################
 }


### PR DESCRIPTION
GDS guidance on telephone number error formats consulted - https://design-system.service.gov.uk/patterns/telephone-numbers/#error-messages

Error state created which will cover scenarios when:
field is left blank
an incorrect format is used

Awaiting BDD to see if we need to add further error states
Screenshot below

![mvp-526 telephone number error - blank and invalid](https://user-images.githubusercontent.com/34911484/49365012-8a1a8800-f6dd-11e8-9268-d7966729fade.png)
