### PR TITLE
MVP-395 Error states for Manual address

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -116,6 +116,8 @@
 			medicalReasonHint:'Describe the medical reasons',
 			otherReasonHint: 'Describe the other reasons',
 			under18DelayReasonHint: 'Explain why this caused a delay',
+			manualAddressErrorBuildingStreetBlank: 'Enter the building and street where you live',
+			manualAddressErrorTownCityBlank: 'Enter the town or city where you live',
 	};
 	// // END__######################################################################################################
 	// }

--- a/app/views/application/address-manually/error-building-street-blank.html
+++ b/app/views/application/address-manually/error-building-street-blank.html
@@ -1,0 +1,119 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+{{ addressQuestion }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" method="post">
+
+      <div class="govuk-form-group">
+        <h1 class="govuk-label-wrapper">
+          <label class="govuk-label govuk-label--xl" for="name">
+            {{ govukErrorSummary({
+                    titleText: "There is a problem",
+                    errorList: [
+                      {
+                        text: manualAddressErrorBuildingStreetBlank,
+                        href: "#address-line-1"
+                      }
+                    ]
+                  }) }}
+          </label>
+        </h1>
+      </div>
+
+      {% from "input/macro.njk" import govukInput %}
+      {% from "fieldset/macro.njk" import govukFieldset %}
+
+      {% call govukFieldset({
+      legend: {
+      text: addressQuestion,
+      classes: "govuk-fieldset__legend--xl",
+      isPageHeading: true
+      }
+      }) %}
+
+      {{ govukInput({
+            label: {
+              html: addressLine1Label
+            },
+            id: "address-line-1",
+            name: "address-line-1",
+            value: data['address-line-1'],
+            errorMessage: {
+            text: manualAddressErrorBuildingStreetBlank
+            }
+
+          }) }}
+
+      {{ govukInput({
+            label: {
+              html: addressLine2Label
+            },
+            id: "address-line-2",
+            name: "address-line-2",
+            value: data['address-line-2']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: townOrCityLabel
+            },
+            classes: "govuk-!-width-two-thirds",
+            id: "address-town",
+            name: "address-town",
+            value: data['address-town']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: countyLabel
+            },
+            classes: "govuk-!-width-two-thirds",
+            id: "address-county",
+            name: "address-county",
+            value: data['address-county']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: addressPostcodeOptionalLabel
+            },
+            classes: "govuk-input--width-10",
+            id: "address-postcode",
+            name: "address-postcode",
+            value: data['address-postcode']
+          }) }}
+
+      {% endcall %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+</main>
+</div>
+
+{% endblock %}
+
+
+<!-- NOTE: do people understand the context of this question? -->

--- a/app/views/application/address-manually/error-town-city-blank.html
+++ b/app/views/application/address-manually/error-town-city-blank.html
@@ -1,0 +1,118 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+{{ addressQuestion }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" method="post">
+
+      <div class="govuk-form-group">
+        <h1 class="govuk-label-wrapper">
+          <label class="govuk-label govuk-label--xl" for="name">
+            {{ govukErrorSummary({
+                    titleText: "There is a problem",
+                    errorList: [
+                      {
+                        text: manualAddressErrorTownCityBlank,
+                        href: "#address-town"
+                      }
+                    ]
+                  }) }}
+          </label>
+        </h1>
+      </div>
+
+      {% from "input/macro.njk" import govukInput %}
+      {% from "fieldset/macro.njk" import govukFieldset %}
+
+      {% call govukFieldset({
+      legend: {
+      text: addressQuestion,
+      classes: "govuk-fieldset__legend--xl",
+      isPageHeading: true
+      }
+      }) %}
+
+      {{ govukInput({
+            label: {
+              html: addressLine1Label
+            },
+            id: "address-line-1",
+            name: "address-line-1",
+            value: data['address-line-1']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              html: addressLine2Label
+            },
+            id: "address-line-2",
+            name: "address-line-2",
+            value: data['address-line-2']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: townOrCityLabel
+            },
+            classes: "govuk-!-width-two-thirds",
+            id: "address-town",
+            name: "address-town",
+            value: data['address-town'],
+            errorMessage: {
+            text: manualAddressErrorTownCityBlank
+            }
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: countyLabel
+            },
+            classes: "govuk-!-width-two-thirds",
+            id: "address-county",
+            name: "address-county",
+            value: data['address-county']
+          }) }}
+
+      {{ govukInput({
+            label: {
+              text: addressPostcodeOptionalLabel
+            },
+            classes: "govuk-input--width-10",
+            id: "address-postcode",
+            name: "address-postcode",
+            value: data['address-postcode']
+          }) }}
+
+      {% endcall %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+</main>
+</div>
+
+{% endblock %}
+
+
+<!-- NOTE: do people understand the context of this question? -->

--- a/app/views/application/address-manually/routes.js
+++ b/app/views/application/address-manually/routes.js
@@ -15,5 +15,13 @@ module.exports = function (router, content) {
   router.get('/application/address-manually/', function (req, res) {
     res.render('application/address-manually/index', content)
   })
+
+  router.get('/application/address-manually/error-building-street-blank', function (req, res) {
+    res.render('application/address-manually/error-building-street-blank', content)
+  })
+
+  router.get('/application/address-manually/error-town-city-blank', function (req, res) {
+    res.render('application/address-manually/error-town-city-blank', content)
+  })
   // END__######################################################################################################
 }


### PR DESCRIPTION
2 error states created as per BDD for when:
- building/street is blank
- town/city is blank
Screenshots below:
![mvp-395 manual address error building or street blank](https://user-images.githubusercontent.com/34911484/49646402-d08e2080-fa16-11e8-8903-55a1d29d72cf.png)
![mvp-395 manual address error town or city blank](https://user-images.githubusercontent.com/34911484/49646403-d08e2080-fa16-11e8-8429-00a79f1b8aa1.png)
