### PR TITLE
MVP-536 Start page content changes

### DIFF
--- a/app/views/application/incident-reported/index.html
+++ b/app/views/application/incident-reported/index.html
@@ -64,7 +64,7 @@
               Our phone lines are open Monday to Friday 8.30am to 5pm except Wednesday when they open at 10am.
             </div>
             <div class="govuk-details__text">
-              You can also <a class="govuk-body" href="https://www.police.uk/contact/101/" target="_blank">contact the Police</a>.
+              You can also <a class="govuk-body" href="https://www.police.uk/contact/101/" target="_blank">contact the police</a>.
             </div>
       </details>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -46,19 +46,21 @@
 
       <p class="govuk-body">If the crime has not been reported to the police we can not pay compensation.</p>
       <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="">another relevant place.</a></p>
-      <p class="govuk-body"><a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services" target="_blank">Northern Ireland</a> has a different service.</p>
+      <p class="govuk-body"><a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services">Northern Ireland</a> has a different service.</p>
 
       <a class="govuk-button govuk-button--start govuk-!-mt-r2 govuk-!-mb-r8" href="application/declaration" role="button">Start now</a>
 
       <h1 class="govuk-heading-l">Before you start
       </h1>
-      <p class="govuk-body">To complete the application we will ask you:</p>
+      <p class="govuk-body">To complete the application we will ask for the:</p>
       <ul class="govuk-list govuk-list--bullet">
         <!-- <li>an email address we can use to contact you</li> -->
-        <li>when the crime happened</li>
-        <li>for the police crime reference number</li>
-        <li>where the crime happened</li>
+        <li>approximate date that the crime happened</li>
+        <li>name of the police force that is dealing with the crime</li>
+        <li>crime reference number</li>
+        <li>location where the crime happened</li>
       </uL>
+      <p class="govuk-body">If you do not have any of this information you can <a href="https://www.police.uk/contact/101/">contact the police</a>.</p>
 
       <p class="govuk-body">Compensation is paid by the government, not the offender. We may be able to pay compensation even if the offender is not identified or convicted.</p>
 
@@ -80,7 +82,7 @@
 
       <h2 class="govuk-heading-l">Help and support
       </h2>
-      <p class="govuk-body">You can find organisations that offer free support and advice by <a href="https://www.victimsinformationservice.org.uk/" target="_blank">contacting the Victims Information Service</a>.</p>
+      <p class="govuk-body">If you need practical or emotional support you can <a href="https://www.victimsinformationservice.org.uk/">visit the Victims' Information Service</a> website.</p>
       <p class="govuk-body">You do not need a legal representative to make an application.</p>
 
 


### PR DESCRIPTION
Content re when and where changed in response to UR insights
hyperlinks updated to make the new screen appear in the same window rather than a new one to aid user navigation
additional guidance content provided in before you start section to link users to police website if they do not have all of the information mentioned in the bullets.