### PR TITLE
MVP-603 Change in contact details content

### DIFF
--- a/app/views/application/application-submitted-email/index.html
+++ b/app/views/application/application-submitted-email/index.html
@@ -14,7 +14,7 @@ Application received - {{ serviceName }} - GOV.UK
     </h2>
 
     <p class="govuk-body">Dear Test User</p>
-    <p class="govuk-body">Your case reference number is OCJ/MVP/2018.</p>
+    <p class="govuk-body">Your case reference number is CICA2123GW.</p>
     <p class="govuk-body">We will normally make a decision within 4 months.</p>
 
     <p class="govuk-body">We will only contact you before the decision is made if:
@@ -23,7 +23,7 @@ Application received - {{ serviceName }} - GOV.UK
         <li class="govuk-body">we need you to clarify something on your application form</li>
       </ul>
     </p>
-    <p class="govuk-body">You must tell us immediately if any of the information you gave us changes.</p>
+    <p class="govuk-body">If your address, telephone number or email address changes you must inform us immediately.</p>
     <p class="govuk-body">You can contact our Customer Service Centre on 0300 003 3601. Select option 8 when the call is answered.</p>
     </div>
 

--- a/app/views/application/application-submitted-email/index.html
+++ b/app/views/application/application-submitted-email/index.html
@@ -23,7 +23,14 @@ Application received - {{ serviceName }} - GOV.UK
         <li class="govuk-body">we need you to clarify something on your application form</li>
       </ul>
     </p>
-    <p class="govuk-body">If your address, telephone number or email address changes you must inform us immediately.</p>
+
+    <p class="govuk-body">You must inform us immediately if any of the information you have given us changes, especially your:
+    <ul>
+      <li class="govuk-body">address</li>
+      <li class="govuk-body">telephone number</li>
+      <li class="govuk-body">email address</li>
+    </ul>
+  </p>
     <p class="govuk-body">You can contact our Customer Service Centre on 0300 003 3601. Select option 8 when the call is answered.</p>
     </div>
 

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -52,7 +52,7 @@ Application submitted - {{ serviceName }} - GOV.UK
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
-        You must tell us immediately if any of the information you gave us changes.
+        If your address, telephone number or email address changes you must inform us immediately.
       </strong>
     </div>
 

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -52,7 +52,7 @@ Application submitted - {{ serviceName }} - GOV.UK
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
-        If your address, telephone number or email address changes you must inform us immediately.
+        You must inform us immediately if any of the information you have given us changes, especially your address, telephone number or email address.
       </strong>
     </div>
 


### PR DESCRIPTION
Latest EMB review meeting, senior stakeholders requested that we be more explicit about the need for users to immediately tell us about changes to their address, email and phone number.  The justification for this is that it is the biggest source of data breaches.
Screenshots of revised content attached below
![mvp-603 application submitted](https://user-images.githubusercontent.com/34911484/51107401-a6363c80-17e6-11e9-8a79-441ce1696ea4.png)
![mvp-603 notify email - application received](https://user-images.githubusercontent.com/34911484/51107409-a8989680-17e6-11e9-82d7-fe09e2e4de10.png)
