### PR TITLE
MVP-251 Error states for reporting delay screen

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -93,6 +93,8 @@ module.exports = {
     previousReferenceHint: 'Enter your previous reference number if you know it (optional)',
     previousApplicationError: 'Select yes if you have applied to us before',
     reportingDelayQuestion: "Select reasons for the delay in reporting the crime to the police",
+    reportingDelayErrorCheckboxes: 'Select if you were under 18, unable to report the crime or other reasons',
+    reportingDelayErrorExplain: 'Explain the reasons for the delay in reporting the crime to the police',
     delayReportExplanation: 'Briefly explain these reasons',
     selectAddressLable: 'Select an address',
     sexualAbuseQuestion: 'Were you a victim of sexual assault or abuse?',

--- a/app/views/application/reporting-delay/error-checkboxes.html
+++ b/app/views/application/reporting-delay/error-checkboxes.html
@@ -1,0 +1,96 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+Error - {{ reportingDelayQuestion }} - {{ serviceName }} - GOV.UK
+Reporting delay
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+}) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
+
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: reportingDelayErrorCheckboxes,
+                  href: "#reportingDelay"
+                }
+              ]
+            }) }}
+
+      {% from "checkboxes/macro.njk" import govukCheckboxes %}
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukCheckboxes({
+            idPrefix: "reportingDelay",
+            name: "reportingDelay",
+            currentValue: data['reportingDelay'],
+            fieldset: {
+              legend: {
+                text: reportingDelayQuestion,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: "Select all options that apply to you."
+            },
+            errorMessage: {
+            text: reportingDelayErrorCheckboxes
+          },
+            items: [
+            {
+              value: "I was under 18",
+              text: "I was under 18"
+            },
+            {
+              value: "Unable to report the crime",
+              text: "Unable to report the crime"
+            },
+            {
+              value: "Other reasons",
+              text: "Other reasons"
+            }
+            ]
+          }) }}
+
+          {% from "textarea/macro.njk" import govukTextarea %}
+
+            {{ govukTextarea({
+                  name: "delay-reporting",
+                  id: "delay-reporting",
+                  currentValue: data['delay-reporting'],
+                  label: {
+                    text: delayReportExplanation,
+                    classes: "govuk-label--l"
+                  }
+                }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+
+</main>
+</div>
+
+{% endblock %}

--- a/app/views/application/reporting-delay/error-explain.html
+++ b/app/views/application/reporting-delay/error-explain.html
@@ -1,0 +1,96 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+Error - {{ reportingDelayQuestion }} - {{ serviceName }} - GOV.UK
+Reporting delay
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+}) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
+
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: reportingDelayErrorExplain,
+                  href: "#delay-reporting"
+                }
+              ]
+            }) }}
+
+      {% from "checkboxes/macro.njk" import govukCheckboxes %}
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukCheckboxes({
+            idPrefix: "reportingDelay",
+            name: "reportingDelay",
+            currentValue: data['reportingDelay'],
+            fieldset: {
+              legend: {
+                text: reportingDelayQuestion,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: "Select all options that apply to you."
+            },
+            items: [
+            {
+              value: "I was under 18",
+              text: "I was under 18"
+            },
+            {
+              value: "Unable to report the crime",
+              text: "Unable to report the crime"
+            },
+            {
+              value: "Other reasons",
+              text: "Other reasons"
+            }
+            ]
+          }) }}
+
+          {% from "textarea/macro.njk" import govukTextarea %}
+
+            {{ govukTextarea({
+                  name: "delay-reporting",
+                  id: "delay-reporting",
+                  currentValue: data['delay-reporting'],
+                  label: {
+                    text: delayReportExplanation
+                  },
+                  errorMessage: {
+                  text: reportingDelayErrorExplain
+                },
+                classes: "govuk-label--l"
+                }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+
+</main>
+</div>
+
+{% endblock %}

--- a/app/views/application/reporting-delay/routes.js
+++ b/app/views/application/reporting-delay/routes.js
@@ -5,8 +5,8 @@ module.exports = function (router, content) {
   // File: reporting-delay
   //
   router.post('/application/reporting-delay', function (req, res) {
-    
-    
+
+
 
     // If the variable is any other value (or is missing) render the page requesteds
     res.redirect('/application/do-you-know-offender')
@@ -22,6 +22,16 @@ module.exports = function (router, content) {
   // Pass the question in to the page
   router.get('/application/reporting-delay/', function (req, res) {
     res.render('application/reporting-delay/index', content)
+  })
+
+  // Pass the error state in to the page when no checkboxes are selected
+  router.get('/application/reporting-delay/error-checkboxes', function (req, res) {
+    res.render('application/reporting-delay/error-checkboxes', content)
+  })
+
+  // Pass the error state in to the page when text field is left empty
+  router.get('/application/reporting-delay/error-explain', function (req, res) {
+    res.render('application/reporting-delay/error-explain', content)
   })
   // END__######################################################################################################
 }


### PR DESCRIPTION
Based on BDD error states created for when user:
1) doesnt select a checkbox option
2) doesnt enter any text in the explanation field

Screenshots below

![mvp-251 reporting delay - no checkboxes selected](https://user-images.githubusercontent.com/34911484/51252558-074f4300-1994-11e9-8d10-b8744782eedb.png)
![mvp-251 reporting delay - no text entered in explanation field](https://user-images.githubusercontent.com/34911484/51252562-09b19d00-1994-11e9-8414-b5fd393b0983.png)
