### PR TITLE
MVP-444 Error state content for application delay screen

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -110,6 +110,8 @@ module.exports = {
     whoIsMakingTheApplicationError: 'Select Myself if you are the person applying for compensation',
     whyDelayQuestion: 'Select reasons for the delay in making your application',
     delayApplyExplanation: 'Briefly explain these reasons',
+    whyDelayErrorCheckboxes: 'Select if you were under 18, advised to wait, medical reasons or other reasons',
+    whyDelayErrorExplain: 'Explain the reasons for the delay in making your application',
     reportedDateErrorPast: 'The date the crime was reported to the police must be in the past',
     reportedDateIncompleteError: 'Enter the date the crime was reported to the police and include a day, month and year',
     reportedDateErrorBlank: 'Enter the date the crime was reported to the police',

--- a/app/views/application/application-delay/error-checkboxes.html
+++ b/app/views/application/application-delay/error-checkboxes.html
@@ -1,0 +1,98 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+Error - {{ whyDelayQuestion }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
+
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: whyDelayErrorCheckboxes,
+                  href: "#whyDelayQuestion"
+                }
+              ]
+            }) }}
+
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukCheckboxes({
+            idPrefix: "applicationDelay",
+            name: "applicationDelay",
+            currentValue: data['applicationDelay'],
+            fieldset: {
+              legend: {
+                text: whyDelayQuestion,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: "Select all options that apply to you."
+            },
+            errorMessage: {
+            text: whyDelayErrorCheckboxes
+          },
+            items: [
+            {
+              value: "I was under 18",
+              text: "I was under 18"
+            },
+            {
+              value: "I was advised to wait",
+              text: "I was advised to wait"
+            },
+            {
+              value: "Medical reasons",
+              text: "Medical reasons"
+            },
+            {
+              value: "Other reasons",
+              text: "Other reasons"
+            }
+            ]
+          }) }}
+
+          {% from "textarea/macro.njk" import govukTextarea %}
+
+            {{ govukTextarea({
+                  name: "delay-application",
+                  id: "delay-application",
+                  currentValue: data['delay-application'],
+                  label: {
+                    text: delayApplyExplanation,
+                    classes: "govuk-label--l"
+                  }
+                }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+
+</main>
+</div>
+
+{% endblock %}

--- a/app/views/application/application-delay/error-explain.html
+++ b/app/views/application/application-delay/error-explain.html
@@ -1,0 +1,98 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+Error - {{ whyDelayQuestion }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" method="post">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
+
+      {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: [
+                {
+                  text: whyDelayErrorExplain,
+                  href: "#delay-application"
+                }
+              ]
+            }) }}
+
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukCheckboxes({
+            idPrefix: "applicationDelay",
+            name: "applicationDelay",
+            currentValue: data['applicationDelay'],
+            fieldset: {
+              legend: {
+                text: whyDelayQuestion,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+              }
+            },
+            hint: {
+              text: "Select all options that apply to you."
+            },
+            items: [
+            {
+              value: "I was under 18",
+              text: "I was under 18"
+            },
+            {
+              value: "I was advised to wait",
+              text: "I was advised to wait"
+            },
+            {
+              value: "Medical reasons",
+              text: "Medical reasons"
+            },
+            {
+              value: "Other reasons",
+              text: "Other reasons"
+            }
+            ]
+          }) }}
+
+          {% from "textarea/macro.njk" import govukTextarea %}
+
+            {{ govukTextarea({
+                  name: "delay-application",
+                  id: "delay-application",
+                  currentValue: data['delay-application'],
+                  label: {
+                    text: delayApplyExplanation },
+                    errorMessage: {
+                    text: whyDelayErrorExplain
+                  },
+                    classes: "govuk-label--l"
+
+                }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+      {{ govukButton({
+          "text": "Continue"
+          }) }}
+
+    </form>
+  </div>
+</div>
+
+</main>
+</div>
+
+{% endblock %}

--- a/app/views/application/application-delay/routes.js
+++ b/app/views/application/application-delay/routes.js
@@ -15,5 +15,15 @@ module.exports = function (router, content) {
   router.get('/application/application-delay/', function (req, res) {
     res.render('application/application-delay/index', content)
   })
+
+  // Pass the error state in to the page when no checkboxes are selected
+  router.get('/application/application-delay/error-checkboxes', function (req, res) {
+    res.render('application/application-delay/error-checkboxes', content)
+  })
+
+  // Pass the error state in to the page when no text is entered in explanation field
+  router.get('/application/application-delay/error-explain', function (req, res) {
+    res.render('application/application-delay/error-explain', content)
+  })
   // END__######################################################################################################
 }


### PR DESCRIPTION
Based on BDDs error states created for when the user:
1) doesnt select a checkbox
2) doesnt enter any text in explanationfield

screenshots below

![mvp-444 application delay - no checkboxes selected](https://user-images.githubusercontent.com/34911484/51254109-32d42c80-1998-11e9-907c-7d756507d7ad.png)
![mvp-444 application delay - no text entered in explanation field](https://user-images.githubusercontent.com/34911484/51254117-37004a00-1998-11e9-8764-9893443f6979.png)
