### PR TITLE
content changes, date fields commented out of No answer

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -151,9 +151,9 @@ module.exports = {
     otherCompensationHint: 'For example, if you claimed insurance, sought civil damages, or a court decided you should get compensation.',
     otherCompensation: 'Have you applied for or received any other form of compensation?',
     compWhoHint:'Who did you apply to?',
-    compDecisionQuestion:'Has a decision been made?',
-    compDecisionYes:'How much did you get, or expect to get?',
-    compDecisionNo:'When will you be notified of a decision? (optional)',
+    compDecisionQuestion:'Have they made a decision?',
+    compDecisionYes:'How much compensation did you get, or expect to get?',
+    // compDecisionNo:'When will you be notified of a decision? (optional)',
 };
 // // END__######################################################################################################
 // }

--- a/app/views/concepts/comp/other-compensation/index.html
+++ b/app/views/concepts/comp/other-compensation/index.html
@@ -43,7 +43,7 @@
 
           {% from "radios/macro.njk" import govukRadios %}
           {% from "input/macro.njk" import govukInput %}
-          {% from "date-input/macro.njk" import govukDateInput %}
+          <!-- {% from "date-input/macro.njk" import govukDateInput %} -->
 
           {% set yesHtml %}
           {{ govukInput({
@@ -60,7 +60,7 @@
           }) }}
           {% endset -%}
 
-          {% set noHtml %}
+          <!-- {% set noHtml %}
           {{ govukDateInput({
             id: "contact-by-email",
             name: "contact-by-email",
@@ -91,7 +91,7 @@
     }
   ]
           }) }}
-          {% endset -%}
+          {% endset -%} -->
 
 
 
@@ -115,12 +115,11 @@
               },
               {
                 value: "No",
-                text: "No",
-                conditional: {
-                  html: noHtml
-                }
-
+                text: "No"
               }
+              
+
+
             ]
           }) }}
 


### PR DESCRIPTION
Content changes made as discussed with @maxinedivers 
have commented out code relating to the conditionally revealing date boxes for a No answer on other comp screen.  Need further evidence to support the claimed business need for this.