### PR TITLE
Start page link to relevant place guidance

### DIFF
--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
+ 
       <h1 class="govuk-heading-xl">
         {{ serviceName }}
       </h1>
@@ -45,7 +45,7 @@
       </ul>
 
       <p class="govuk-body">If the crime has not been reported to the police we can not pay compensation.</p>
-      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="">another relevant place.</a></p>
+      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location">another relevant place.</a></p>
       <p class="govuk-body">There is a different service for <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services">Northern Ireland</a>.</p>
 
       <a class="govuk-button govuk-button--start govuk-!-mt-r2 govuk-!-mb-r8" href="application/declaration" role="button">Start now</a>


### PR DESCRIPTION
Updated link on start page to connect to the new relevant place guidance created in CICA guidance pages.