### PR TITLE
MVP-731 Posting decision letter

### DIFF
--- a/app/views/application/application-submitted-email/index.html
+++ b/app/views/application/application-submitted-email/index.html
@@ -15,6 +15,7 @@ Application received - {{ serviceName }} - GOV.UK
 
     <p class="govuk-body">Your case reference number is CICA2123GW.</p>
     <p class="govuk-body">We will usually make a decision within 4 months.</p>
+    <p class="govuk-body">We will send our decision letter by post.</p>
 
     <p class="govuk-body">We will only contact you before the decision is made if:
       <ul>
@@ -23,15 +24,19 @@ Application received - {{ serviceName }} - GOV.UK
       </ul>
     </p>
 
-    <p class="govuk-body">You must inform us immediately if any of the information you have given us changes, especially your:
-    <ul>
-      <li class="govuk-body">address</li>
-      <li class="govuk-body">telephone number</li>
-      <li class="govuk-body">email address</li>
-    </ul>
-  </p>
-    <p class="govuk-body">You can contact our Customer Service Centre on 0300 003 3601. Select option 8 when the call is answered.</p>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">You must inform us immediately if any of the information you have given us changes, especially your:
+        <ul>
+          <li class="govuk-body">address</li>
+          <li class="govuk-body">telephone number</li>
+          <li class="govuk-body">email address</li>
+        </ul>
+      </p>
+      <p class="govuk-body">You can contact our Customer Service Centre on 0300 003 3601. Select option 8 when the call is answered.</p>
+
     </div>
+  </div>
 
     <form class="form" method="post">
 

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -47,7 +47,7 @@ Application submitted - {{ serviceName }} - GOV.UK
     </ul>
 
     <p class="govuk-body">We will usually make a decision within 4 months.</p>
-    <p class="govuk-body">A letter explaining our decision will be posted to the address in your application.</p>
+    <p class="govuk-body">We will post a letter to you to explain our decision.</p>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -30,10 +30,10 @@ Application submitted - {{ serviceName }} - GOV.UK
       <div class="govuk-panel__body">
         Your reference number is<br><strong>CICA2123GW</strong>
       </div>
-      
+
       <p></p>
 
-      <div class="govuk-panel__body">
+      <div class="govuk-panel__body-l">
         We have sent a confirmation email to <strong>{{ data['emailAddress'] }}</strong>
       </div>
     </div>

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -47,6 +47,7 @@ Application submitted - {{ serviceName }} - GOV.UK
     </ul>
 
     <p class="govuk-body">We will usually make a decision within 4 months.</p>
+    <p class="govuk-body">A letter explaining our decision will be posted to the address in your application.</p>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -28,14 +28,18 @@ Application submitted - {{ serviceName }} - GOV.UK
         Application submitted
       </h2>
       <div class="govuk-panel__body">
-        Your reference number<br><strong>CICA2123GW</strong>
+        Your reference number is<br><strong>CICA2123GW</strong>
+      </div>
+      
+      <p></p>
+
+      <div class="govuk-panel__body">
+        We have sent a confirmation email to <strong>{{ data['emailAddress'] }}</strong>
       </div>
     </div>
-    <p>
-    </p>
-    <p class="govuk-body-l">Thank you for submitting your application.</p>
+    <p></p>
 
-    <p class="govuk-body-l">We have sent a confirmation email to <strong>{{ data['emailAddress'] }}</strong></p>
+    <p class="govuk-body">Thank you for submitting your application.</p>
 
     <h2 class="govuk-heading-m">What happens next</h2>
 
@@ -43,11 +47,10 @@ Application submitted - {{ serviceName }} - GOV.UK
     <ul class="govuk-list govuk-list--bullet">
       <li>ask the police for evidence</li>
       <li>use the police evidence to make a decision</li>
-      <li>send our decision to {{ data['emailAddress'] }}</li>
+      <li>send our decision letter by post</li>
     </ul>
 
     <p class="govuk-body">We will usually make a decision within 4 months.</p>
-    <p class="govuk-body">We will post a letter to you to explain our decision.</p>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>


### PR DESCRIPTION
We need to tell users that their decision letter will be posted to them, as we do not yet have an end to end digital journey in place.

Attached is screenshot of "Application submitted" page content for review.  We would mirror this in the Notify email that is sent to users.

![mvp-731 application submitted page](https://user-images.githubusercontent.com/34911484/53495101-1ea34500-3a97-11e9-8996-7f307313bd48.png)
