### PR TITLE
MVP-730 email content

### DIFF
--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
- 
+
       <h1 class="govuk-heading-xl">
         {{ serviceName }}
       </h1>
@@ -52,6 +52,9 @@
 
       <h1 class="govuk-heading-l">Before you start
       </h1>
+
+      <p class="govuk-body">You need an email address to use this service.</p>
+
       <p class="govuk-body">To complete the application we will ask for the:</p>
       <ul class="govuk-list govuk-list--bullet">
         <!-- <li>an email address we can use to contact you</li> -->


### PR DESCRIPTION
Added a new line of content under the Before you start heading telling users that they need an email to use the MVP service.