### PR TITLE
MVP-693 OCJ option 2 redirect content

### DIFF
--- a/app/routes-content.js
+++ b/app/routes-content.js
@@ -110,6 +110,7 @@ module.exports = {
     singleOrMultipleIncidentsQuestion: 'Did the crime happen once or over a period of time?',
     townOrCityLabel: 'Town or city',
     transitionHeading: 'You are being redirected to our other application site',
+    transitionHeadingOption2: 'You cannot use this service right now',
     warningText: "If you deliberately give false or misleading information, you may get less compensation or be prosecuted.",
     whatIsRelationshipQuestion: "If you have contact with the offender, describe it below",
     whatIsRelationshipError: "Enter details of any contact you have with the offender",

--- a/app/routes.js
+++ b/app/routes.js
@@ -61,6 +61,7 @@ require('./views/application/reporting-delay/routes')(router, viewContent);
 require('./views/application/confirmation-page-if-automatic-nil/routes')(router, viewContent);
 
 require('./views/application/transition/routes')(router, viewContent);
+require('./views/application/transition-OCJ-option-2/routes')(router, viewContent);
 
 // Police MVP //
 require('./views/application/england-location/routes')(router, viewContent);

--- a/app/views/application/transition-OCJ-option-2/index.html
+++ b/app/views/application/transition-OCJ-option-2/index.html
@@ -1,0 +1,52 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+{{ transitionHeadingOption2 }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ transitionHeadingOption2 }}
+    </h1>
+    <p class="govuk-body">To apply for sexual assault or abuse, and additional injuries or financial losses, you must <a href="https://www.cica.gov.uk/oas/Account/Create" target="_blank">use the current service</a> (opens in a new window).</p>
+
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Need help or support?
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">You can contact us for help with your application on 0300 003 3601. Select option 8.</p>
+        <p class="govuk-body">Our phone lines are open Monday to Friday 8.30am to 5pm except Wednesday when they open at 10am.</p>
+        <p class="govuk-body">For practical or emotional support in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information</a> website.</p>
+        <p class="govuk-body">There is a different website if you live in <a href="https://www.mygov.scot/victim-witness-support/">Scotland</a>.</p>
+        </div>
+    </details>
+
+    <form class="form" method="post">
+
+    </form>
+  </div>
+</div>
+
+</main>
+
+</div>
+
+{% endblock %}

--- a/app/views/application/transition-OCJ-option-2/routes.js
+++ b/app/views/application/transition-OCJ-option-2/routes.js
@@ -1,0 +1,18 @@
+module.exports = function (router, content) {
+  // START__####################################################################################################
+  // File: transition
+
+  router.post('/application/transition-OCJ-option-2', function (req, res) {
+    if (req.session.checking_answers) { //the user was coming from the check your answer page, we are returning them there
+      return res.redirect('/application/check-your-answers-page')
+    }
+    res.redirect('https://www.cica.gov.uk/OAS/Account/Create')
+  })
+
+  // Pass the question in to the page
+  router.get('/application/transition-OCJ-option-2/', function (req, res) {
+    res.render('application/transition-OCJ-option-2/index', content)
+  })
+
+  // END__######################################################################################################
+}

--- a/app/views/application/your-choices/routes.js
+++ b/app/views/application/your-choices/routes.js
@@ -12,7 +12,7 @@ module.exports = function (router, content) {
       res.redirect('/application/incident-reported')
     } else {
       // If the variable is any other value (or is missing) render the page requested
-      res.redirect('/application/transition')
+      res.redirect('/application/transition-OCJ-option-2')
     }
   })
 


### PR DESCRIPTION
PB users selecting option 2 on the OCJ screen will be redirected to the OAS service.  We need a more descriptive transition page to explain exactly why they are being redirected and reassure that they have done nothing wrong.  Support is available via phone to CSC or other 3rd part organisations (if user isnt signposted by them)

Demo of how it works below

![mvp-693-demo-of-option-2-transition-journey](https://user-images.githubusercontent.com/34911484/53635655-b3cc4800-3c15-11e9-83ea-1c50e0611fd6.gif)
