### PR TITLE
Content updates

### DIFF
--- a/app/views/application/confirmation-page/index.html
+++ b/app/views/application/confirmation-page/index.html
@@ -42,7 +42,7 @@ Application submitted - {{ serviceName }} - GOV.UK
     <ul class="govuk-list govuk-list--bullet">
       <li>ask the police for evidence</li>
       <li>use the police evidence to make a decision</li>
-      <li>send our decision to {{ data['emailAddress'] }}</li>
+      <li>send our decision letter by post</li>
     </ul>
 
     <p class="govuk-body">We will usually make a decision within 4 months.</p>

--- a/app/views/application/consent/index.html
+++ b/app/views/application/consent/index.html
@@ -34,7 +34,7 @@
 
       <h2 class="govuk-heading-l">Your consent</h2>
 
-      <p class="govuk-body">By selecting the 'Agree and apply' you:</p>
+      <p class="govuk-body">By selecting 'Agree and apply' you:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>agree to test our new service</li>
         <li>consent to us contacting you for feedback</li>

--- a/app/views/application/reporting-crime-not-reported/index.html
+++ b/app/views/application/reporting-crime-not-reported/index.html
@@ -25,7 +25,7 @@
           {{ notEligibleHeading }}
         </label>
       </h1>
-      <p class="govuk-body-l">If the crime has not been reported to the police we can not pay compensation.</p>
+      <p class="govuk-body-l">If the crime has not been reported to the police we cannot pay compensation.</p>
       <p class="govuk-body">You may continue your application, but any future application for the same injuries will be refused.</p>
     </div>
     <form class="form" method="post">


### PR DESCRIPTION
@Julieallan @maxinedivers 
I reviewed the prototype content and identified 3 anomolies:

- an extra 'the' in the Your consent section of PB Consent
- 'can not' on the ineligiblity screen that needed changed to 'cannot'
- 3rd bullet on confirmation screen did not reflect recent change re posting the decision letter

all changes effected by this pull request
