### PR TITLE
MVP-785 Notify email survey content

### DIFF
--- a/app/views/application/application-submitted-email/index.html
+++ b/app/views/application/application-submitted-email/index.html
@@ -24,7 +24,6 @@ Application received - {{ serviceName }} - GOV.UK
       </ul>
     </p>
 
-
       <div class="govuk-details__text">
         <p class="govuk-body">You must inform us immediately if any of the information you have given us changes, especially your:
         <ul>
@@ -36,6 +35,22 @@ Application received - {{ serviceName }} - GOV.UK
       <p class="govuk-body">You can contact our Customer Service Centre on 0300 003 3601. Select option 8 when the call is answered.</p>
 
     </div>
+    <br>
+    <br>
+    <div>
+      <h2 class="govuk-heading-l">
+      Help us improve our service
+      </h2>
+
+      <p>If you have not done so already, you can complete a short survey to help us improve our service. It will take around 10 minutes.</p>
+
+      <p>The survey does not ask for any details about your case, and has no effect on your application.</p>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">Complete the survey at <a href='https://www.gov.uk/'>https://www.gov.uk/</a></p>
+      </div>
+
+      </div>
   </div>
 
     <form class="form" method="post">


### PR DESCRIPTION
Notify email content updated to include an invitation to user feedback survey.  This is a replication of the content in the Notify template, for use in prototype testing.  Screenshot below

![MVP-785 Notify email with survey content - prototype version](https://user-images.githubusercontent.com/34911484/54271277-21169c00-4579-11e9-8282-60455b70c29c.png)
