### PR TITLE
Instant support right hand column concept

### DIFF
--- a/app/views/concepts/instant-support/index.html
+++ b/app/views/concepts/instant-support/index.html
@@ -1,0 +1,145 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+{{ yourChoicesHeading }} - {{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+}) }}
+<!--<a class="govuk-back-link" href="javascript: history.go(-1)">Back</a>-->
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Select the option that applies to you
+    </h1>
+
+
+    <p class="govuk-body-l">We decide what enquiries to make depending on how the crime affected you.</p>
+
+    <h2 class="govuk-heading-m">
+      Option 1: Sexual assault or abuse
+    </h2>
+
+    <p class="govuk-body">Any compensation we pay acknowledges the emotional distress the crime caused you.</p>
+    <p class="govuk-body">We normally make a decision based on your application and the information we get from the police.</p>
+    <p class="govuk-body">We will usually make a decision within 4 months.  This is because we do not normally need to see your medical records.</p>
+
+    <h2 class="govuk-heading-m">
+      Option 2: Sexual assault or abuse and other injuries or losses
+    </h2>
+
+    <p class="govuk-body">We can also pay compensation for:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>lost earnings because you were unable to work</li>
+      <li>physical injuries</li>
+      <li>pregnancy, sexually transmitted disease or loss of foetus</li>
+      <li>disabling mental injuries that are additional to the emotional distress you already suffered</li>
+    </ul>
+
+    <form class="form" method="post">
+
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            What is a disabling mental injury?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+        <p>A disabling mental injury has a substantial adverse effect on your ability to carry out normal day-to-day activities. For example, reduced performance at school or work, or effects on your social or sexual relationships.</p>
+        </div>
+      </details>
+
+      <p class="govuk-body">We may ask a psychiatrist or clinical psychologist to confirm that you have a disabling mental injury if you do not already have a diagnosis.</p>
+  <p class="govuk-body">We will usually make a decision within 12 months. This is because we may need to examine your medical records, get medical reports and assess any losses.</p>
+
+    <!--  <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            If you need help or support
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">You can contact us for help with your application on 0300 003 3601. Select option 8.</p>
+          <p class="govuk-body">Our phone lines are open Monday to Friday 8.30am to 5pm except Wednesday when they open at 10am.</p>
+          <p class="govuk-body">For practical or emotional support visit the Victim and Witness infomation websites:
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="https://www.victimandwitnessinformation.org.uk/"  target="_blank">England and Wales</a></li>
+            <li><a href="https://www.mygov.scot/victim-witness-support/"  target="_blank">Scotland</a></li>
+            </ul>
+              </p>
+        </div>
+      </details>-->
+
+      {% from 'radios/macro.njk' import govukRadios %}
+
+      {{ govukRadios({
+            "classes": "govuk-radios",
+            "idPrefix": "yourChoice",
+            "name": "yourChoice",
+            currentValue: data['yourChoice'],
+            "fieldset": {
+              "legend": {
+                "text": 'Select the option that applies to you',
+                "isPageHeading": false,
+                "classes": 'govuk-fieldset__legend--m'
+              }
+            },
+            "items": [
+            {
+              value: "Option 1: Sexual assault or abuse",
+              text: "Option 1: Sexual assault or abuse",
+              label: {
+                classes: "govuk-label--s"
+              }
+            },
+            {
+              "value": "Sexual assault or abuse and other injuries or losses",
+              "text": "Option 2: Sexual assault or abuse and other injuries or losses",
+              label: {
+                classes: "govuk-label--s"
+              }
+            }
+            ]
+          }) }}
+
+      <a class="govuk-button govuk-!-mt-r2 govuk-!-mb-r8" href="/concepts/support/start-page" role="button">Continue</a>
+    </form>
+  </div>
+
+<!--Instant support - Right hand side column-->
+  <div class="govuk-grid-column-one-third">
+    <aside class="app-related-items" role="complementary">
+        <a class="govuk-button" href="http://www.google.com" style="background-color:#6f777b"> Instantly exit to google</a>
+        <h2 class="govuk-heading-m" id="subsection-title">
+        Help and support
+      </h2>
+      <nav role="navigation" aria-labelledby="subsection-title">
+        <p class="govuk-body">For help with your application, you can contact us on 0300 003 3601. Select option 8.</p>
+        <p class="govuk-body">Phone lines are open Monday to Friday 8.30am to 5pm except Wednesday when they open at 10am.</p>
+        <p class="govuk-body">Victim and Witness infomation support websites:
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://www.victimandwitnessinformation.org.uk/"  target="_blank">England and Wales</a></li>
+          <li><a href="https://www.mygov.scot/victim-witness-support/"  target="_blank">Scotland</a></li>
+          </ul>
+            </p>
+      </nav>
+    </aside>
+  </div>
+
+</div>
+
+</main>
+
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Would like to get your thoughts on this concept @Julieallan @johnkane1 

The idea is that the user will go to google and the back button will be disabled. Thats the bit I was focussing on but think we could add the contact and support info here too so that its on every screen - what you think? Maybe even on pages such as police force or CRN we can add a bit of copy to say if you are unsure you can contact the police on 101 etc....?

Trying to keep this section as small and unobtrusive as possible though. 

I've used a secondary button here that isn't in the design system but was one I used at DWP and looks like GDS are working on new secondary and tertiary buttons.

Also if we go ahead with this and test it in PB then MOJ would like to put it into their design system for other teams to use. Would need to be tested thoroughly though.