### PR TITLE
Instant support 

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -106,6 +106,7 @@
     <ul class="govuk-list">
       <li><a class="govuk-link" href="/srr">'Same roof' rule</a></li>
       <li><a class="govuk-link" href="/concepts/support/start-page.html">Help and support content</a></li>
+      <li><a class="govuk-link" href="/concepts/instant-support">Instant support</a></li>
     </ul>
           </section>
 


### PR DESCRIPTION
New pull request sorry - original comment:

Would like to get your thoughts on this concept @Julieallan @johnkane1

The idea is that the user will go to google and the back button will be disabled. Thats the bit I was focussing on but think we could add the contact and support info here too so that its on every screen - what you think? Maybe even on pages such as police force or CRN we can add a bit of copy to say if you are unsure you can contact the police on 101 etc....?

Trying to keep this section as small and unobtrusive as possible though.

I've used a secondary button here that isn't in the design system but was one I used at DWP and looks like GDS are working on new secondary and tertiary buttons.

Also if we go ahead with this and test it in PB then MOJ would like to put it into their design system for other teams to use. Would need to be tested thoroughly though.