### PR TITLE
MVP-855 Private Beta start page content

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Apply for criminal injuries compensation',
+  serviceName: 'Claim criminal injuries compensation',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -69,7 +69,7 @@
       <p class="govuk-body">Contact us if:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>you cannot use digital services at all, this might be due to disability or your circumstances</li>
-          <li>you have a question about your claim and can’t access your online claim</li>
+          <li>you have a question about your application</li>
         </ul>
       <p class="govuk-inset-text">
       Telephone: 0300 003 3601. Select option 8.<br>

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -34,28 +34,11 @@
       <h1 class="govuk-heading-xl">
         {{ serviceName }}
       </h1>
-      <p class="govuk-body-l">Use this service to apply for compensation if:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>you were the victim of a sexual crime or abuse</li>
-        <li>you suffered mental injuries because of a violent crime</li>
-        <li>you suffered physical injuries because of a violent crime</li>
-        <li>you saw a violent crime happen to a loved one, or were there immediately afterwards</li>
-        <li>a close relative died because of a violent crime</li>
-        <li>you paid for the funeral of someone who died because of a violent crime</li>
-      </ul>
+      <p class="govuk-body-l">Use this service to apply for compensation if you were the victim of a sexual crime or abuse.</p>
 
-      <p class="govuk-body">If the crime has not been reported to the police we can not pay compensation.</p>
-      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location"  target="_blank">another relevant place.</a></p>
-      <p class="govuk-body">There is a different service for <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services"  target="_blank">Northern Ireland</a>.</p>
+      <p class="govuk-body">Compensation is paid by the government, not the assailant. It may be payable even if the assailant is not identified or convicted.</p>
 
-      <a class="govuk-button govuk-button--start govuk-!-mt-r2 govuk-!-mb-r8" href="application/declaration" role="button">Start now</a>
-
-      <h1 class="govuk-heading-l">Before you start
-      </h1>
-
-      <p class="govuk-body">You need an email address to use this service.</p>
-
-      <p class="govuk-body">To complete the application we will ask for the:</p>
+      <p class="govuk-body">You need an email address to use this service. You will also need:</p>
       <ul class="govuk-list govuk-list--bullet">
         <!-- <li>an email address we can use to contact you</li> -->
         <li>approximate date that the crime happened</li>
@@ -63,30 +46,42 @@
         <li>crime reference number</li>
         <li>location where the crime happened</li>
       </uL>
-      <p class="govuk-body">If you do not have any of this information you can <a href="https://www.police.uk/contact/101/"  target="_blank">contact the police</a>.</p>
-
-      <p class="govuk-body">Compensation is paid by the government, not the assailant. We may be able to pay compensation even if the assailant is not identified or convicted.</p>
+      <p class="govuk-body">You can <a href="https://www.police.uk/contact/101/"  target="_blank">contact the police for any missing information</a>.</p>
 
       <h2 class="govuk-heading-l">
         Eligibility
       </h2>
-      <p class="govuk-body">Usually you must apply within 2 years of when the crime happened. We may be able to make an exception if you:</p>
+      <p class="govuk-body">You cannot get compensation if the crime has not been reported to the police.</p>
+      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location"  target="_blank">another relevant place</a>. There is a <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services"  target="_blank">different service for Northern Ireland</a>.</p>
+
+      <p class="govuk-body">Usually you must apply within 2 years of when the crime happened. An exception may be made if you:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>were under 18 at the time</li>
         <li>can show that you could not apply earlier</li>
       </ul>
 
+      <a class="govuk-button govuk-button--start govuk-!-mt-r2 govuk-!-mb-r8" href="application/declaration" role="button">Start now</a>
+
       <h2 class="govuk-heading-l">
         Other ways to apply
       </h2>
-      <p class="govuk-body">You can contact us for help with your application on 0300 003 3601. Select option 8.</p>
-
-      <p class="govuk-body">Our phone lines are open Monday to Friday 8.30am to 5pm except Wednesday when they open at 10am.</p>
+      <p class="govuk-body">Contact us if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you cannot use digital services at all, this might be due to disability or your circumstances</li>
+          <li>you have a question about your claim and can’t access your online claim</li>
+        </ul>
+      <p class="govuk-inset-text">
+      Telephone: 0300 003 3601. Select option 8.<br>
+      Overseas: +44 (0)20 3684 2517<br>
+      Monday, Tuesday, Thursday Friday, 8.30am to 5pm<br>
+      Wednesday, 10am to 5pm<br>
+      <a href="https://www.gov.uk/call-charges">Find out about call charges.</a>
+      </p>
 
       <h2 class="govuk-heading-l">Help and support
       </h2>
       <p class="govuk-body">For practical or emotional support in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information</a> website.</p>
-      <p class="govuk-body">There is a different website if you live in <a href="https://www.mygov.scot/victim-witness-support/">Scotland</a>.</p>
+      <p class="govuk-body">There is a <a href="https://www.mygov.scot/victim-witness-support/">different website if you live in Scotland</a>.</p>
             </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -81,7 +81,7 @@
 
       <h2 class="govuk-heading-l">Help and support
       </h2>
-      <p class="govuk-body">For practical or emotional support in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information</a> website.</p>
+      <p class="govuk-body">For practical or emotional support in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information website</a>.</p>
       <p class="govuk-body">There is a <a href="https://www.mygov.scot/victim-witness-support/">different website if you live in Scotland</a>.</p>
             </div>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -34,7 +34,7 @@
       <h1 class="govuk-heading-xl">
         {{ serviceName }}
       </h1>
-      <p class="govuk-body-l">Use this service to apply for compensation if you were the victim of a sexual crime or abuse.</p>
+      <p class="govuk-body-l">Use this service to claim compensation if you were the victim of a sexual crime or abuse.</p>
 
       <p class="govuk-body">Compensation is paid by the government, not the assailant. It may be payable even if the assailant is not identified or convicted.</p>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -81,9 +81,12 @@
 
       <h2 class="govuk-heading-l">Help and support
       </h2>
-      <p class="govuk-body">For practical or emotional support in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information website</a>.</p>
-      <p class="govuk-body">There is a <a href="https://www.mygov.scot/victim-witness-support/">different website if you live in Scotland</a>.</p>
-            </div>
+      <p class="govuk-body">You can get practical or emotional support depending on where you live:</p>
+        <ul class="govuk-list govuk-list--bullet">
+         <li>in England and Wales <a href="https://www.victimandwitnessinformation.org.uk/">visit the Victim and Witness Information website</a></li>
+         <li>in Scotland <a href="https://www.mygov.scot/victim-witness-support/">visit the mygov.scot website</a></li>
+        </ul>
+      </div>
 
     <div class="govuk-grid-column-one-third">
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -52,7 +52,8 @@
         Eligibility
       </h2>
       <p class="govuk-body">You cannot get compensation if the crime has not been reported to the police.</p>
-      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location"  target="_blank">another relevant place</a>. There is a <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services"  target="_blank">different service for Northern Ireland</a>.</p>
+      <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location"  target="_blank">another relevant place</a>.</p>
+      <p class="govuk-inset-text">There is a <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services"  target="_blank">different service for Northern Ireland</a>.</p>
 
       <p class="govuk-body">Usually you must apply within 2 years of when the crime happened. An exception may be made if you:</p>
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This iteration has been designed in response to the following feedback from GDS:

- On GOV.UK, we don’t use ‘we’ or ‘us’ on mainstream content, ie in ‘To complete the application we ask for the:’ This would be more like... ‘To apply, you’ll need:’
- Layout and wording of the contact info in ‘Other ways to apply’ would appear as a content block (like the one on Universal Credit how to claim page). You can find the Govspeak mark up for ‘Contacts’ here
- use meaningful links that make sense when read out of context and are action focused (for accessibility). For example:
- ‘Contact the police’ needs something explaining in what context you’d do this in the link text
- ‘There’s a different website if you live in [Scotland]’ - ‘Scotland’ read aloud by a screenreader won’t make a lot of sense, needs the context too
- We currently can’t change the start page pattern, but we can look to edit down what currently appears above the green button. Look at bringing some of the key ‘Before you start’ and ‘Eligibility’ info into the intro copy (above the green button). GDS did this with the fees info on the Register your trailer to take it abroad’ start page
- Consider reducing the number of bullet points links (at the top of your start page) that cover violent crime, as the service is primarily for sexual abuse victims right now. It could set false expectations for what the service can currently do.

Re: bullet point 2 - I am unable to replicate that style of "block content" in the prototype kit so have used existing design system "inset" pattern.  I have tried to accomodate all of the other points.